### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ BZGMailgunEmailValidator *validator =
 * Caveat implementor: success and failure blocks are executed on the main queue.
 
 ### Installation
-If you're using Cocoapods, simply add `pod 'BZGMailgunEmailValidation'` to your `Podfile`. 
+If you're using CocoaPods, simply add `pod 'BZGMailgunEmailValidation'` to your `Podfile`. 
 
 Otherwise, add `BZGMailgunEmailValidator.h` and `BZGMailgunEmailValidator.m` to your project.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
