### PR TITLE
docs: correct CocoaPods spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ BZGMailgunEmailValidator *validator =
 * Caveat implementor: success and failure blocks are executed on the main queue.
 
 ### Installation
-If you're using Cocoapods, simply add `pod 'BZGMailgunEmailValidation'` to your `Podfile`. 
+If you're using CocoaPods, simply add `pod 'BZGMailgunEmailValidation'` to your `Podfile`.
 
 Otherwise, add `BZGMailgunEmailValidator.h` and `BZGMailgunEmailValidator.m` to your project.
 


### PR DESCRIPTION
Replays the valid one-line documentation fix from #8 onto current `master` because the original contributor branch is no longer available for updating. It also removes the trailing space already present on the corrected line.\n\nPreserves the original contributor as commit author.